### PR TITLE
Resolves issue #49

### DIFF
--- a/app/sass/blocks/_showcase.scss
+++ b/app/sass/blocks/_showcase.scss
@@ -1,3 +1,4 @@
+#forstudents,
 #profile,
 #know,
 #video,


### PR DESCRIPTION
Fixed spanning image in #forstudents home page block. As a reminder,
there is a generic .showcase class that does the same thing. We’ll want
to move to using this class at some point (modifying formats).
