### PR TITLE
responsive iframe embeds

### DIFF
--- a/app/js/responsive.js
+++ b/app/js/responsive.js
@@ -49,5 +49,28 @@
     }
     
   });
-
 });
+
+//IFRAMES
+function adjustIframes()
+{
+    $('iframe').each(function(){
+        var
+            $this       = $(this),
+            proportion  = $this.data( 'proportion' ),
+            w           = $this.attr('width'),
+            actual_w    = $this.width();
+
+        if ( ! proportion )
+        {
+            proportion = $this.attr('height') / w;
+            $this.data( 'proportion', proportion );
+        }
+
+        if ( actual_w != w )
+        {
+            $this.css( 'height', Math.round( actual_w * proportion ) + 'px' );
+        }
+    });
+}
+$(window).on('resize load',adjustIframes);

--- a/app/sass/base/_typography.scss
+++ b/app/sass/base/_typography.scss
@@ -55,3 +55,7 @@ input[type="text"] {
   border: 1px solid $sand-dark;
   border-radius: $border-radius-base;
 }
+
+iframe {
+  max-width: 100%;
+}


### PR DESCRIPTION
This fix allows the iframe width to be set inline (from the pasted code), but when the responsive page shrinks the iframe becomes a percent and also shrinks. In other words, the user can set the width on the full page view.
