### PR TITLE
fix: 🐛 Reduce gap between links; switch site and global nav to standard case

### DIFF
--- a/src/sass/components/_navigation-site.scss
+++ b/src/sass/components/_navigation-site.scss
@@ -1,14 +1,14 @@
 // The main navigation bar on every page
 
 .main-header {
-  margin-bottom: 2em;
+  margin-bottom: 3em;
   position: relative;
 }
 
 .main-navigation {
   margin-bottom: 0;
   .home & {
-    margin-bottom: 1.2em;
+    margin-bottom: 1.5em;
   }
 }
 
@@ -16,7 +16,7 @@
 .site-nav {
   display:flex;
   justify-content: flex-start;
-  gap: 1em  2.5em;
+  gap: 1em  2em;
   padding:0;
   margin:0;
   flex-direction: column;
@@ -34,7 +34,7 @@
     list-style: none;
     font-family: $font-family-sans-serif;
     font-size: 1.1em;
-    text-transform: uppercase;
+    text-transform: none;
     font-weight: 500;
 
     a, span {
@@ -56,7 +56,7 @@
     & > span {
       background: transparent url(../images/down-arrow.svg) no-repeat right 60%;
       background-size: 14px;
-      padding: 0 20px 0 0;
+      padding: 0 16px 0 0;
     }
 
     @include media($small-desktop-plus) {
@@ -94,14 +94,17 @@
     border: 1px solid $brand-light-gray;
     margin: 0;
     width: fit-content;
-    min-width: 14em;
-    margin-top: -1px;
-    padding: 5px 0;
+    min-width: 12em;
+    margin-top: 0;
+    padding: 6px 0;
     position: absolute;
     left: -900em;
 
+    @include module-box-shadow(dark);
+    border-radius: unset;
+
     li {
-      font-size: .8em;
+      font-size: .85em;
       float: none;
       display: block;
       text-align: left;
@@ -109,7 +112,7 @@
 
       a {
         text-transform: none;
-        padding: .25em .75em;
+        padding: .3em .8em;
         border: none;
 
         &:focus,

--- a/src/sass/regions/_top-row.scss
+++ b/src/sass/regions/_top-row.scss
@@ -94,7 +94,7 @@
     }
 
     a {
-      text-transform: uppercase;
+      text-transform: none;
       color: $brand-tertiary-blue;
       padding: .25em .5em;
     }

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -30,4 +30,4 @@ mix.copyDirectory("src/images", "assets/images");
 //     server: "./dist"
 // });
 
-mix.copy(["src/netlify/index.html", "src/netlify/_headers"], "assets");
+mix.copy(["src/netlify/index.html"], "assets");


### PR DESCRIPTION
This fixes an issue where site navigation was compressed and unreadable on smaller screens. Site nav with more than 7 links may break to two lines on some screen widths, but will remain readable.

Site navigation items may break to two lines at some screen widths.

## Before
- Links are uppercase
- Links need wider spacing to remain readable 
![screenshot-2022-01-20-123936](https://user-images.githubusercontent.com/36719/150419807-6485ccc6-f900-49b6-b0a6-3c0c3fffab6d.jpeg)

## After
- Links in main nav and global nav are standard case to [improve readability and accessibility](https://blog.prototypr.io/all-caps-on-ui-good-or-bad-2570f14dc457)
- Spacing between links slightly reduced
- Links are left aligned instead of justified (_changed on 1/19/2022_)
![screenshot-2022-01-20-124147](https://user-images.githubusercontent.com/36719/150420192-6ce66c8d-68bc-447f-9e34-033784fc8daf.jpeg)

