### PR TITLE
fix: 🐛 Fix for unsupported 'gap' property in CSS

### DIFF
--- a/src/sass/components/_navigation-site.scss
+++ b/src/sass/components/_navigation-site.scss
@@ -16,10 +16,8 @@
 .site-nav {
   display:flex;
   justify-content: flex-start;
-  row-gap: 1em;
-  column-gap: 2em;
+  margin: -1em 0 0 -1.6em;
   padding:0;
-  margin:0;
   flex-direction: column;
 
   @include media($tablet) {
@@ -31,7 +29,7 @@
 
   li {
     padding:0;
-    margin:0;
+    margin: 1em 0 0 1.6em;
     list-style: none;
     font-family: $font-family-sans-serif;
     font-size: 1.1em;
@@ -106,6 +104,7 @@
 
     li {
       font-size: .85em;
+      margin: 0;
       float: none;
       display: block;
       text-align: left;

--- a/src/sass/regions/_top-row.scss
+++ b/src/sass/regions/_top-row.scss
@@ -82,13 +82,10 @@
     flex-direction: row;
     flex-wrap: wrap;
     font-size: .9em;
-    margin: 0;
-    row-gap: .8em;
-    column-gap: .8em;
-    
+    margin: -0.8em 0 0 -0.8em;
     
     li {
-      margin: 0;
+      margin: 0.8em 0 0 0.8em;
       padding:0;
       list-style: none;
       flex: 1 1 46%;
@@ -104,8 +101,7 @@
     @include media($tablet) {
 
         flex-wrap: nowrap;
-        gap: 0.8em;
-        margin: 0;
+        margin: -0.8em 0 0 -0.8em;
 
         > li {          
           line-height: 1.2em;


### PR DESCRIPTION
Safari 14.0 and below (4% of traffic) do not support column-gap or row-gap in flex.